### PR TITLE
Update README.md for log-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ If you are not using a `Gemfile`, run:
 Use from Rails:
 
     config.logger = RemoteSyslogLogger.new('syslog.domain.com', 514, :program => "rails-#{RAILS_ENV}")
+    config.logger.level = Logger::INFO # ... or Logger::DEBUG (if development)
 
 Use from Ruby:
 


### PR DESCRIPTION
The default example for setting log level is `config.log_level = :info`... not `config.logger.level = Logger::INFO`. This lead to some confusion during setup when my production environment switched from INFO (which it was set to with config.log_level) to debug whenever I used this papertrail gem.

This may be responsible for the surprisingly large number of production environments in debug you guys have encountered...

> _Confirm existing verbosity_: make sure your app is not unintentionally logging at DEBUG level. **This is much more common than it sounds.**

([Quote from papertrail's support page](http://help.papertrailapp.com/kb/configuration/controlling-verbosity/))
