### PR TITLE
Obey Syslog size limits

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,7 @@ task :coverage do
   sh "open coverage/index.html"
 end
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
   rdoc.title = "#{name} #{version}"

--- a/lib/remote_syslog_logger/limit_bytesize.rb
+++ b/lib/remote_syslog_logger/limit_bytesize.rb
@@ -1,0 +1,18 @@
+# Adapted from http://stackoverflow.com/a/12536366/2778142
+def limit_bytesize(str, size)
+  # Change to canonical unicode form (compose any decomposed characters).
+  # Works only if you're using active_support
+  str = str.mb_chars.compose.to_s if str.respond_to?(:mb_chars)
+
+  # Start with a string of the correct byte size, but
+  # with a possibly incomplete char at the end.
+  new_str = str.byteslice(0, size)
+
+  # We need to force_encoding from utf-8 to utf-8 so ruby will re-validate
+  # (idea from halfelf).
+  until new_str[-1].force_encoding(new_str.encoding).valid_encoding?
+    # remove the invalid char
+    new_str = new_str.slice(0..-2)
+  end
+  new_str
+end

--- a/lib/remote_syslog_logger/udp_sender.rb
+++ b/lib/remote_syslog_logger/udp_sender.rb
@@ -17,7 +17,13 @@ module RemoteSyslogLogger
 
       @packet.facility = options[:facility] || 'user'
       @packet.severity = options[:severity] || 'notice'
-      @packet.tag      = options[:program]  || "#{File.basename($0)}[#{$$}]"
+      @packet.tag      = options[:program]  || default_tag
+    end
+
+    def default_tag
+      pid_suffix = "[#{$$}]"
+      max_basename_size = 32 - pid_suffix.size
+      "#{File.basename($0)}"[0...max_basename_size].gsub(/[^\x21-\x7E]/, '_') + pid_suffix
     end
     
     def transmit(message)

--- a/remote_syslog_logger.gemspec
+++ b/remote_syslog_logger.gemspec
@@ -50,6 +50,9 @@ Gem::Specification.new do |s|
   ## that are needed for an end user to actually USE your code.
   s.add_dependency('syslog_protocol')
 
+  s.add_development_dependency('rake')
+  s.add_development_dependency('test-unit')
+
   ## List your development dependencies here. Development dependencies are
   ## those that are only needed during development
   # s.add_development_dependency('DEVDEPNAME', [">= 1.1.0", "< 2.0.0"])

--- a/remote_syslog_logger.gemspec
+++ b/remote_syslog_logger.gemspec
@@ -49,6 +49,7 @@ Gem::Specification.new do |s|
   ## List your runtime dependencies here. Runtime dependencies are those
   ## that are needed for an end user to actually USE your code.
   s.add_dependency('syslog_protocol')
+  s.add_dependency('activesupport', '>= 3.2.14', '< 5.1')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('test-unit')

--- a/remote_syslog_logger.gemspec
+++ b/remote_syslog_logger.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |s|
   ## List your runtime dependencies here. Runtime dependencies are those
   ## that are needed for an end user to actually USE your code.
   s.add_dependency('syslog_protocol')
-  s.add_dependency('activesupport', '>= 3.2.14', '< 5.1')
+  s.add_dependency('activesupport', '>= 3.2.14')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('test-unit')

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,4 +9,4 @@ end
 
 require 'remote_syslog_logger'
 
-require 'test/unit'
+require 'minitest/autorun'

--- a/test/test_remote_syslog_logger.rb
+++ b/test/test_remote_syslog_logger.rb
@@ -1,6 +1,6 @@
 require File.expand_path('../helper', __FILE__)
 
-class TestRemoteSyslogLogger < Test::Unit::TestCase
+class TestRemoteSyslogLogger < MiniTest::Test
   def setup
     @server_port = rand(50000) + 1024
     @socket = UDPSocket.new

--- a/test/test_remote_syslog_logger.rb
+++ b/test/test_remote_syslog_logger.rb
@@ -25,4 +25,23 @@ class TestRemoteSyslogLogger < Test::Unit::TestCase
     message, addr = *@socket.recvfrom(1024)
     assert_match /This is the second line/, message
   end
+
+  def test_logger_default_tag
+    $0 = 'foo'
+    logger = RemoteSyslogLogger.new('127.0.0.1', @server_port)
+    logger.info ""
+
+    message, addr = *@socket.recvfrom(1024)
+    assert_match "foo[#{$$}]: I,", message
+  end
+
+  def test_logger_long_default_tag
+    $0 = 'x' * 64
+    pid_suffix = "[#{$$}]"
+    logger = RemoteSyslogLogger.new('127.0.0.1', @server_port)
+    logger.info ""
+
+    message, addr = *@socket.recvfrom(1024)
+    assert_match 'x' * (32 - pid_suffix.size) + pid_suffix + ': I,', message
+  end
 end

--- a/test/test_remote_syslog_logger.rb
+++ b/test/test_remote_syslog_logger.rb
@@ -44,4 +44,84 @@ class TestRemoteSyslogLogger < Test::Unit::TestCase
     message, addr = *@socket.recvfrom(1024)
     assert_match 'x' * (32 - pid_suffix.size) + pid_suffix + ': I,', message
   end
+
+  TEST_TAG = 'foo'
+  TEST_HOSTNAME = 'bar'
+  TEST_FACILITY = 'user'
+  TEST_SEVERITY = 'notice'
+  TEST_MESSAGE = "abcdefg" * 512
+
+  def test_logger_long_message
+    _test_msg_splitting_with(
+      tag: TEST_TAG,
+      hostname: TEST_HOSTNAME,
+      severity: TEST_SEVERITY,
+      facility: TEST_FACILITY,
+      message: TEST_MESSAGE,
+      max_packet_size: nil,
+      continuation_prefix: nil)
+  end
+
+  def test_logger_long_message_custom_packet_size
+    _test_msg_splitting_with(
+      tag: TEST_TAG,
+      hostname: TEST_HOSTNAME,
+      severity: TEST_SEVERITY,
+      facility: TEST_FACILITY,
+      message: TEST_MESSAGE,
+      max_packet_size: 2048,
+      continuation_prefix: nil)
+  end
+
+  def test_logger_long_message_custom_continuation
+    _test_msg_splitting_with(
+      tag: TEST_TAG,
+      hostname: TEST_HOSTNAME,
+      severity: TEST_SEVERITY,
+      facility: TEST_FACILITY,
+      message: TEST_MESSAGE,
+      max_packet_size: nil,
+      continuation_prefix: 'frobnicate')
+  end
+
+  private
+
+  class MessageOnlyFormatter < ::Logger::Formatter
+    def call(severity, timestamp, progname, msg)
+      msg
+    end
+  end
+
+  def _test_msg_splitting_with(options)
+    logger = RemoteSyslogLogger.new('127.0.0.1', @server_port,
+                                    program: options[:tag],
+                                    local_hostname: options[:hostname],
+                                    severity: options[:severity],
+                                    facility: options[:facility],
+                                    max_packet_size: options[:max_packet_size],
+                                    continuation_prefix: options[:continuation_prefix])
+    logger.formatter = MessageOnlyFormatter.new
+    logger.info options[:message]
+
+    packet_size = options[:max_packet_size] || 1024
+    continuation_prefix = options[:continuation_prefix] || '... '
+
+    test_packet = SyslogProtocol::Packet.new
+    test_packet.hostname = options[:hostname]
+    test_packet.tag = options[:tag]
+    test_packet.severity = options[:severity]
+    test_packet.facility = options[:facility]
+    test_packet.content = ''
+    max_content_size = packet_size - test_packet.assemble.size
+
+    offset = 0
+    line_prefix = ''
+    while offset < options[:message].size
+      chunk_size = max_content_size - line_prefix.size
+      message, addr = *@socket.recvfrom(packet_size * 2)
+      assert_match Regexp.new(': ' + line_prefix + Regexp.escape(options[:message][offset...offset + chunk_size]) + '$'), message
+      offset += chunk_size
+      line_prefix = continuation_prefix
+    end
+  end
 end


### PR DESCRIPTION
- Ensure default tag is max 32 characters long
- Split long lines into chunks so they aren't truncated by Syslog max message size
