### PR TITLE
Lock logging gem to < 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source :rubygems
 
 gemspec
 
+gem 'logging', '< 2'


### PR DESCRIPTION
See issue here: https://github.com/papertrail/remote_syslog_logger/issues/12