### PR TITLE
Fix log being truncated by increasing max packet size

### DIFF
--- a/lib/remote_syslog_logger/udp_sender.rb
+++ b/lib/remote_syslog_logger/udp_sender.rb
@@ -7,6 +7,7 @@ module RemoteSyslogLogger
       @remote_hostname = remote_hostname
       @remote_port     = remote_port
       @whinyerrors     = options[:whinyerrors]
+      @maxsize         = options[:maxsize] || 30720
       
       @socket = UDPSocket.new
       @packet = SyslogProtocol::Packet.new
@@ -26,7 +27,8 @@ module RemoteSyslogLogger
           next if line =~ /^\s*$/
           packet = @packet.dup
           packet.content = line
-          @socket.send(packet.assemble, 0, @remote_hostname, @remote_port)
+          payload = packet.assemble @maxsize
+          @socket.send(payload, 0, @remote_hostname, @remote_port)
         rescue
           $stderr.puts "#{self.class} error: #{$!.class}: #{$!}\nOriginal message: #{line}"
           raise if @whinyerrors

--- a/lib/remote_syslog_logger/udp_sender.rb
+++ b/lib/remote_syslog_logger/udp_sender.rb
@@ -7,7 +7,7 @@ module RemoteSyslogLogger
       @remote_hostname = remote_hostname
       @remote_port     = remote_port
       @whinyerrors     = options[:whinyerrors]
-      @maxsize         = options[:maxsize] || 30720
+      @max_size        = options[:max_size]
       
       @socket = UDPSocket.new
       @packet = SyslogProtocol::Packet.new
@@ -27,7 +27,7 @@ module RemoteSyslogLogger
           next if line =~ /^\s*$/
           packet = @packet.dup
           packet.content = line
-          payload = packet.assemble @maxsize
+          payload = @max_size ? packet.assemble(@max_size) : packet.assemble
           @socket.send(payload, 0, @remote_hostname, @remote_port)
         rescue
           $stderr.puts "#{self.class} error: #{$!.class}: #{$!}\nOriginal message: #{line}"


### PR DESCRIPTION
I believe this fixes the problem of logs being truncated at near 1024 bytes.

Related issue: #15 

The issue is caused since [`SyslogProtocol::Packet#assemble`][1] has a default `max_size` of 1024.

This PR sets the max default size to 30k and provides a way to modify it on initialization.

It was tested against Papertrail, and it works as expected - large log events are sent without being truncated, and tcpdump shows that the `DF` flag is no longer applied to the outgoing message.

You can test with this self contained script:

```ruby
require 'bundler/inline'

gemfile do
  gem 'remote_syslog_logger', github: 'dannyben/remote_syslog_logger', tag: 'v1.0.3.1'
end

# Config here
host    = 'logsN.papertrailapp.com'
port    = XXXXX

logger = RemoteSyslogLogger.new host, port, max_size: 30000
message = (1..2000).to_a.join ' '
logger.info message
```

Will you consider merging?



[1]: https://github.com/eric/syslog_protocol/blob/master/lib/syslog_protocol/packet.rb#L10